### PR TITLE
Blocked error logging for dev only session storage setup

### DIFF
--- a/ProjectSourceCode/index.js
+++ b/ProjectSourceCode/index.js
@@ -63,14 +63,15 @@ app.use(bodyParser.json());
 
 app.use(
   session({
-      store: new FileStore({
-          path: './sessions',
-          ttl: 86400 // 1 day in seconds
-      }),
-      secret: process.env.SESSION_SECRET,
-      resave: false,
-      saveUninitialized: false,
-      cookie: { maxAge: 24 * 60 * 60 * 1000 } // 1 day
+    store: new FileStore({
+      path: './sessions',
+      ttl: 86400, // 1 day in seconds
+      logFn: function () {}, // Suppress logging
+    }),
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: { maxAge: 24 * 60 * 60 * 1000 } // 1 day
   })
 );
 


### PR DESCRIPTION
Just added a simple function to block the annoying (but not causing issues) error caused by our persistent session solution. 

The error in question:
![Screenshot 2025-03-31 at 16 57 04](https://github.com/user-attachments/assets/b0299b27-5a15-4b2b-95d3-b303cd06ffa9)
